### PR TITLE
使用 mistune 完成 html 和 Markdown 的双向转换

### DIFF
--- a/core/tasks.py
+++ b/core/tasks.py
@@ -296,4 +296,4 @@ def chunk_translate(original_content: str, target_language: str, engine: Transla
                 )
         else:
             translated_content.append(cached["text"])
-    return "".join(translated_content), total_tokens, total_characters, need_cache_objs
+    return "\n\n".join(translated_content), total_tokens, total_characters, need_cache_objs

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -12,7 +12,6 @@ django-debug-toolbar
 django-huey-monitor
 whitenoise
 uvicorn
-html2text
 fake-useragent
 cityhash
 mistune

--- a/utils/chunk_handler.py
+++ b/utils/chunk_handler.py
@@ -1,23 +1,17 @@
 import logging
 import re
 
-#from itertools import groupby
-import html2text
+from itertools import groupby
 import tiktoken
-
+import mistune
 
 def content_split(content: str) -> dict:
     """Split content into chunks, separated by two newlines."""
     # https://github.com/openai/openai-cookbook/blob/main/examples/How_to_count_tokens_with_tiktoken.ipynb
     encoding = tiktoken.get_encoding("cl100k_base")
     try:
-        h = html2text.HTML2Text()
-        h.mark_code = True
-        h.unicode_snob = True
-        h.body_width = 0
-        h.bypass_tables = True
-        # h.images_as_html = True
-        content = h.handle(h.handle(content))  # 经测试，遇到解码后的html标签(&lt;p&gt;&lt), 需要转换2次
+        markdown = mistune.create_markdown(escape=False)
+        content = markdown(content)
         chunks = content.split('\n\n')
         tokens = []
         characters = []


### PR DESCRIPTION
经过测试，使用 mistune 进行双向转化的效果最佳，废弃之前的 html2text 和 markdwonify 的方案