### PR TITLE
使用 Markdownify 替换 Html2text 将 HTML 转换为 Markdown

### DIFF
--- a/core/tasks.py
+++ b/core/tasks.py
@@ -296,4 +296,4 @@ def chunk_translate(original_content: str, target_language: str, engine: Transla
                 )
         else:
             translated_content.append(cached["text"])
-    return "".join(translated_content), total_tokens, total_characters, need_cache_objs
+    return "\n\n".join(translated_content), total_tokens, total_characters, need_cache_objs

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -12,7 +12,7 @@ django-debug-toolbar
 django-huey-monitor
 whitenoise
 uvicorn
-html2text
 fake-useragent
 cityhash
 mistune
+markdownify

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -8,10 +8,8 @@ httpx
 dateutils
 huey
 gevent
-django-debug-toolbar
-django-huey-monitor
-whitenoise
 uvicorn
+whitenoise
 fake-useragent
 cityhash
 mistune

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -8,9 +8,11 @@ httpx
 dateutils
 huey
 gevent
-uvicorn
+django-debug-toolbar
+django-huey-monitor
 whitenoise
-html2text
+uvicorn
 fake-useragent
 cityhash
 mistune
+markdownify

--- a/utils/chunk_handler.py
+++ b/utils/chunk_handler.py
@@ -11,7 +11,7 @@ def content_split(content: str) -> dict:
     encoding = tiktoken.get_encoding("cl100k_base")
     try:
         markdown = md(content)
-        chunks = markdown.split('\n\n')
+        chunks = re.split('\n+', markdown)
         tokens = []
         characters = []
         for chunk in chunks:

--- a/utils/chunk_handler.py
+++ b/utils/chunk_handler.py
@@ -1,24 +1,17 @@
 import logging
 import re
 
-#from itertools import groupby
-import html2text
+from itertools import groupby
 import tiktoken
-
+from markdownify import markdownify as md
 
 def content_split(content: str) -> dict:
     """Split content into chunks, separated by two newlines."""
     # https://github.com/openai/openai-cookbook/blob/main/examples/How_to_count_tokens_with_tiktoken.ipynb
     encoding = tiktoken.get_encoding("cl100k_base")
     try:
-        h = html2text.HTML2Text()
-        h.mark_code = True
-        h.unicode_snob = True
-        h.body_width = 0
-        h.bypass_tables = True
-        # h.images_as_html = True
-        content = h.handle(h.handle(content))  # 经测试，遇到解码后的html标签(&lt;p&gt;&lt), 需要转换2次
-        chunks = content.split('\n\n')
+        markdown = md(content)
+        chunks = markdown.split('\n\n')
         tokens = []
         characters = []
         for chunk in chunks:
@@ -59,7 +52,7 @@ def group_chunks(split_chunks: dict, min_size: int, max_size: int,
         for chunk, value in zip(chunks, values):
             if value > max_size:
                 # Use regex to split the chunk at symbol boundaries
-                split_points = re.finditer(r'[\s\.,;!?]+', chunk)
+                split_points = re.finditer(r'[\s.!?]+', chunk)
                 last_split_end = 0
                 for match in split_points:
                     if match.start() - last_split_end >= max_size:


### PR DESCRIPTION
1. 经过多个源的测试，Markdownify 能非常好的将 HTML 转化为 Markdown 格式
2. Markdown 文本在 group 处理时，超过长度的分隔符去除 ,;，可能能够避免一些切割后导致乱码的情况，这部分还需要后续继续测试优化
3. 拼接翻译后的 chunk 时，将连接符调整为 \n\n，能够很好的实现换行效果，提升可读性
