### PR TITLE
Skip MathMl translations with katex class

### DIFF
--- a/utils/text_handler.py
+++ b/utils/text_handler.py
@@ -144,6 +144,10 @@ def should_skip(element):
     if element.find_parents(skip_tags):
         return True
 
+    # check if the element class is katex for MathMl
+    if element.find_parent("span", class_="katex"):
+        return True
+
     text = element.get_text(strip=True)
     if not text:
         return True


### PR DESCRIPTION
Mathematical formulas are translated unexpectedly. 
This code skips the translation by checking if the span tag is a descendant of a katex class. 

Such as the article in [1], we should skip the <span> tag with `class=katex`.

[1] https://huggingface.co/blog/whitecircle-ai/circleguardbench